### PR TITLE
Ui: Reset multiselect actions when refreshing listView in Instance page

### DIFF
--- a/ui/scripts/ui/widgets/listView.js
+++ b/ui/scripts/ui/widgets/listView.js
@@ -2494,6 +2494,8 @@
                 this.data('view-args').sections[activeSection].listView :
                 this.data('view-args').listView;
 
+            toggleMultiSelectActions(this, false);
+
             loadBody(
                 this.find('table:last'),
                 listViewArgs.dataProvider,


### PR DESCRIPTION
## Description
Enables the toolbar to reset to its initial state after any multiSelectAction completed.

Fixes: https://github.com/apache/cloudstack/issues/3337

## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots:
<img width="1088" alt="Screen Shot 2019-05-26 at 22 34 29" src="https://user-images.githubusercontent.com/8104993/58386379-ab628e00-8007-11e9-94fd-878e62741ffd.png">


## How Has This Been Tested?
Open Instances 
Select any instance, on the toolbar Take VM Snapshot, Destroy Instance, Stop Instance  buttons will be visible.
Follow operation path for any of these buttons.
Listview and toolbar will reset to its initial state.

